### PR TITLE
fix(yfmlint): keep error level after double normalization #5243

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,11 +62,19 @@ export function normalizeConfig(...parts: RawLintConfig[]) {
                     loglevel: part[key] as LogLevels,
                 };
             } else if (part[key] && typeof part[key] === 'object') {
-                // Object config: merge with loglevel from 'level' property or default
+                // Object config: keep extra rule fields (e.g. YFM001.maximum) and
+                // resolve the level. Read the input `level`, fall back to an
+                // already-normalized `loglevel` (so normalizeConfig stays idempotent
+                // when called on its own output), then to the default. The source
+                // `level` is dropped so the result carries a single `loglevel` field.
+                const {level, loglevel, ...rest} = part[key] as {
+                    level?: LogLevels;
+                    loglevel?: LogLevels;
+                    [x: string]: unknown;
+                };
                 result[key] = {
-                    ...(part[key] as object),
-                    // @ts-ignore
-                    loglevel: part[key].level || DEFAULT_LOG_LEVEL,
+                    ...rest,
+                    loglevel: level || loglevel || DEFAULT_LOG_LEVEL,
                 };
             }
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,90 @@
+import {describe, expect, it} from 'vitest';
+import dedent from 'ts-dedent';
+
+import {LogLevels, normalizeConfig, yfmlint} from '../src';
+
+// Markdown that violates two standard markdownlint rules:
+// - MD018 (no-space-after-hash): heading without a space after `#`
+// - MD010 (no-hard-tabs): a line indented with a real TAB character
+// The tab is injected via an explicit `\t` escape so it can't be lost to
+// editor/prettier reformatting (unlike a tab stored in a fixture file).
+const reproInput = ['#Heading without space', '', '\tLine indented with a hard tab', ''].join('\n');
+
+describe('normalizeConfig', () => {
+    it('normalizes boolean, string and object rule forms to {loglevel}', () => {
+        const config = normalizeConfig({
+            MD001: true,
+            MD002: false,
+            MD003: LogLevels.ERROR,
+            YFM001: {level: LogLevels.WARN, maximum: 80},
+        });
+
+        expect(config.MD001).toEqual({loglevel: LogLevels.WARN});
+        // `false` (disabled) is simplified back to `false`
+        expect(config.MD002).toBe(false);
+        expect(config.MD003).toEqual({loglevel: LogLevels.ERROR});
+        expect(config.YFM001).toEqual({loglevel: LogLevels.WARN, maximum: 80});
+    });
+
+    // Regression: config is normalized twice (once in the CLI Lint feature,
+    // once inside yfmlint). An already-normalized `{loglevel: 'error'}` has no
+    // `.level`, so the second pass used to fall back to the default WARN,
+    // silently downgrading errors and letting the build pass.
+    it('is idempotent for an already-normalized config', () => {
+        const once = normalizeConfig({MD010: LogLevels.ERROR, MD018: LogLevels.ERROR});
+        const twice = normalizeConfig(once);
+
+        expect(twice).toEqual(once);
+        expect((twice.MD010 as {loglevel: LogLevels}).loglevel).toBe(LogLevels.ERROR);
+        expect((twice.MD018 as {loglevel: LogLevels}).loglevel).toBe(LogLevels.ERROR);
+    });
+
+    it('preserves extra object rule fields (e.g. YFM001.maximum) on re-normalization', () => {
+        const once = normalizeConfig({YFM001: {level: LogLevels.ERROR, maximum: 80}});
+        const twice = normalizeConfig(once);
+
+        expect(twice.YFM001).toEqual({loglevel: LogLevels.ERROR, maximum: 80});
+    });
+});
+
+describe('yfmlint log levels', () => {
+    it('keeps MD010/MD018 at error level when config was pre-normalized (CLI flow)', async () => {
+        // Simulate the CLI flow: config already normalized before reaching yfmlint.
+        const preNormalized = normalizeConfig({
+            MD010: LogLevels.ERROR,
+            MD018: LogLevels.ERROR,
+        });
+
+        const errors =
+            (await yfmlint(reproInput, 'repro.md', {
+                lintConfig: preNormalized,
+            })) || [];
+
+        const byRule = (name: string) => errors.filter((e) => e.ruleNames.includes(name));
+
+        expect(byRule('MD010').length).toBeGreaterThan(0);
+        expect(byRule('MD018').length).toBeGreaterThan(0);
+
+        for (const error of [...byRule('MD010'), ...byRule('MD018')]) {
+            expect(error.level).toBe(LogLevels.ERROR);
+        }
+    });
+
+    it('honours a raw (not pre-normalized) rule level too', async () => {
+        const errors =
+            (await yfmlint(
+                dedent`
+                #Heading without space
+            `,
+                'raw.md',
+                {
+                    lintConfig: {MD018: LogLevels.ERROR},
+                },
+            )) || [];
+
+        const md018 = errors.filter((e) => e.ruleNames.includes('MD018'));
+
+        expect(md018.length).toBeGreaterThan(0);
+        expect(md018[0].level).toBe(LogLevels.ERROR);
+    });
+});


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request, before submitting, please read commit message formatting guidelines at https://www.conventionalcommits.org/en/v1.0.0/

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that the code is up-to-date with the `master` branch.
4. Include a description of the proposed changes and how to test them.

For Russian speaking contributors:
Перед отправкой PR-a, пожалуйста, прочтите гайды для разработчиков платформы Diplodoc : https://diplodoc.com/docs/ru/dev/
#xxxx" -->

## Description

fixes #5243

The E2E tests are here: https://github.com/diplodoc-platform/cli/pull/2071

### Problem

Standard markdownlint rules (MD010, MD018, etc.) configured as `error` in `.yfmlint` were silently downgraded to `warn`. As a result, the build kept passing when it should have failed — the violations were only written to the log at WARN level.

### Root cause

The lint config is normalized twice by two independent layers:

1. **CLI** — the `Lint` feature expands the `log-levels` section, merges it with the config, and calls `normalizeConfig` (needed to support `log-levels` and to append `MD033`).
2. **`yfmlint` package** — being a self-contained library, it calls `normalizeConfig` again when merging with its default config.

`normalizeConfig` was **not idempotent**: when processing the object form of a rule, the level was read only from the `.level` field. An already-normalized object `{loglevel: 'error'}` has no `.level`, so the fallback to the default `warn` kicked in and the original `error` was lost.

### Fix

Added a fallback to the already-present `loglevel` field in the object-normalization branch:

```ts
loglevel: objectConfig.level || objectConfig.loglevel || DEFAULT_LOG_LEVEL
```

Re-running normalization on an already-normalized config now yields the same result, and the `error` level is preserved. Neither of the two `normalizeConfig` calls had to be removed — both are required for the respective layers to work correctly.

Related issue: #5243

<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
