### PR TITLE
feat(yfmlint): detect non-BMP (UTF-16) characters #367

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,20 @@ Validates that links to autotitle anchors reference existing titles.
 
 ### YFM011 - Max SVG size
 
-**Tags:** `image_svg`  
+**Tags:** `image_svg`
 **Aliases:** `max-svg-size`
 
 Validates that SVG images don't exceed the maximum size limit. Requires image processing plugins from `@diplodoc/transform`.
+
+### YFM021 - Non-BMP (UTF-16 surrogate pair) character
+
+**Tags:** `encoding`, `utf16`
+**Aliases:** `no-non-bmp-characters`
+
+Detects characters outside the Unicode Basic Multilingual Plane (code point > `U+FFFF`). Such characters are encoded as UTF-16 surrogate pairs (e.g. emoji, rare CJK ideographs, mathematical alphanumeric symbols) and are known to break layout in some browsers. Reported as an error by default so that these characters do not reach production.
+
+**Example:**
+
+```markdown
+Hello 😀 world
+```

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,4 +21,5 @@ export default {
     YFM011: LogLevels.WARN, // Max svg size
     YFM018: LogLevels.INFO, // Term definition from include
     YFM020: LogLevels.WARN, // Unknown or invalid YFM directive
+    YFM021: LogLevels.ERROR, // Non-BMP (UTF-16 surrogate pair) character breaks layout
 };

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -11,3 +11,4 @@ export {yfm010} from './yfm010';
 export {yfm011} from './yfm011';
 export {yfm018} from './yfm018';
 export {yfm020} from './yfm020';
+export {yfm021} from './yfm021';

--- a/src/rules/yfm021.ts
+++ b/src/rules/yfm021.ts
@@ -1,0 +1,60 @@
+import type {Rule} from 'markdownlint';
+
+/**
+ * Formats a character as its Unicode code point notation, e.g. "U+1F600".
+ *
+ * @param char - A single Unicode character (may be a surrogate pair)
+ * @returns Code point in "U+XXXX" notation
+ */
+function toCodePoint(char: string): string {
+    const codePoint = char.codePointAt(0) || 0;
+
+    return 'U+' + codePoint.toString(16).toUpperCase().padStart(4, '0');
+}
+
+/**
+ * YFM021 - Non-BMP (UTF-16 surrogate pair) character.
+ *
+ * Detects characters outside the Unicode Basic Multilingual Plane
+ * (code point > U+FFFF). In UTF-16 such characters are encoded as
+ * surrogate pairs and are known to break layout in some browsers.
+ *
+ * The rule scans every line (iterating by code point, so surrogate pairs
+ * are treated as a single character) and reports each occurrence so that
+ * these characters do not reach production.
+ */
+export const yfm021: Rule = {
+    names: ['YFM021', 'no-non-bmp-characters'],
+    description: 'UTF-16 surrogate-pair character may break layout in some browsers',
+    tags: ['encoding', 'utf16'],
+    parser: 'markdownit',
+    function: function YFM021(params, onError) {
+        const {config} = params;
+        if (!config) {
+            return;
+        }
+
+        params.lines.forEach((line, index) => {
+            let column = 0;
+
+            // Iterating a string with for..of yields code points,
+            // so a surrogate pair is handled as a single character.
+            for (const char of line) {
+                column += 1;
+
+                const codePoint = char.codePointAt(0) || 0;
+
+                if (codePoint > 0xffff) {
+                    onError({
+                        lineNumber: index + 1,
+                        detail:
+                            `Character ${toCodePoint(char)} '${char}' is outside the Basic ` +
+                            `Multilingual Plane (UTF-16 surrogate pair) at column ${column} ` +
+                            `and may break layout in some browsers`,
+                        context: line,
+                    });
+                }
+            }
+        });
+    },
+};

--- a/test/yfm021.test.ts
+++ b/test/yfm021.test.ts
@@ -1,0 +1,81 @@
+import {describe, expect, it} from 'vitest';
+import dedent from 'ts-dedent';
+
+import {LogLevels, yfmlint} from '../src';
+
+import {formatErrors} from './utils';
+
+describe('YFM021', () => {
+    it('reports emoji (non-BMP character)', async () => {
+        const input = 'Hello 😀 world';
+
+        const errors =
+            (await yfmlint(input, 'test.md', {lintConfig: {YFM021: LogLevels.ERROR}})) || [];
+
+        expect(formatErrors(errors)).toEqual([
+            'test.md: 1: YFM021 / no-non-bmp-characters UTF-16 surrogate-pair character may break layout in some browsers [Character U+1F600 \'😀\' is outside the Basic Multilingual Plane (UTF-16 surrogate pair) at column 7 and may break layout in some browsers] [Context: "Hello 😀 world"]',
+        ]);
+    });
+
+    it('reports multiple non-BMP characters on different lines', async () => {
+        const input = dedent`
+            First line 𝕏
+
+            Second line 🚀
+        `;
+
+        const errors =
+            (await yfmlint(input, 'test.md', {lintConfig: {YFM021: LogLevels.ERROR}})) || [];
+
+        const filtered = formatErrors(errors).filter((e) => e.includes('YFM021'));
+
+        expect(filtered).toHaveLength(2);
+        expect(filtered[0]).toContain('test.md: 1:');
+        expect(filtered[0]).toContain('U+1D54F');
+        expect(filtered[1]).toContain('test.md: 3:');
+        expect(filtered[1]).toContain('U+1F680');
+    });
+
+    it('reports errors with ERROR log level', async () => {
+        const input = 'Broken 𝐀';
+
+        const errors =
+            (await yfmlint(input, 'test.md', {lintConfig: {YFM021: LogLevels.ERROR}})) || [];
+
+        const logs = errors.filter((error) => error.level === LogLevels.ERROR);
+
+        expect(logs).toHaveLength(1);
+    });
+
+    it('does not report regular BMP characters (latin, cyrillic, punctuation)', async () => {
+        const input = dedent`
+            Обычный текст with regular ASCII — and «typographic» quotes.
+
+            Символы вне ASCII: é, ñ, ü, ©, ®, №.
+        `;
+
+        const errors =
+            (await yfmlint(input, 'test.md', {lintConfig: {YFM021: LogLevels.ERROR}})) || [];
+
+        expect(formatErrors(errors).filter((e) => e.includes('YFM021'))).toEqual([]);
+    });
+
+    it('is enabled by default as an error', async () => {
+        const input = 'Emoji 😀';
+
+        const errors = (await yfmlint(input, 'test.md', {lintConfig: {}})) || [];
+
+        const logs = errors.filter((error) => error.level === LogLevels.ERROR);
+
+        expect(logs).toHaveLength(1);
+    });
+
+    it('can be disabled via config', async () => {
+        const input = 'Emoji 😀';
+
+        const errors =
+            (await yfmlint(input, 'test.md', {lintConfig: {YFM021: LogLevels.DISABLED}})) || [];
+
+        expect(formatErrors(errors).filter((e) => e.includes('YFM021'))).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Description

### What

Added a new rule **YFM021** (`no-non-bmp-characters`) to the @diplodoc/yfmlint linter, which finds characters outside the Basic Multilingual Plane (code point > `U+FFFF`). These characters are encoded as surrogate pairs in UTF-16 (emoji, rare characters, and mathematical alphabets) and break layout in some browsers.

### Why

To prevent these characters from reaching production. The rule is enabled by default with the `error` level, so their presence causes the documentation build to fail and is logged as an error.

### How it works

The rule iterates through the document's contents line by line by code points (a surrogate pair is considered as one character) and reports each occurrence with line number, column and code point (for example `U+1F600`). Normal non-ASCII characters from BMP (Cyrillic, é, ©, "quotes", dash) are not considered as an error. The rule can be disabled using `YFM021: disabled` in `.yfmlint`.

Related issue: #367
