### PR TITLE
feat(yfmlint): detect non-BMP (UTF-16) characters, LogLevel = warn

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -21,5 +21,5 @@ export default {
     YFM011: LogLevels.WARN, // Max svg size
     YFM018: LogLevels.INFO, // Term definition from include
     YFM020: LogLevels.WARN, // Unknown or invalid YFM directive
-    YFM021: LogLevels.ERROR, // Non-BMP (UTF-16 surrogate pair) character breaks layout
+    YFM021: LogLevels.WARN, // Non-BMP (UTF-16 surrogate pair) character breaks layout
 };

--- a/test/yfm021.test.ts
+++ b/test/yfm021.test.ts
@@ -60,12 +60,12 @@ describe('YFM021', () => {
         expect(formatErrors(errors).filter((e) => e.includes('YFM021'))).toEqual([]);
     });
 
-    it('is enabled by default as an error', async () => {
+    it('is enabled by default as a warning', async () => {
         const input = 'Emoji 😀';
 
         const errors = (await yfmlint(input, 'test.md', {lintConfig: {}})) || [];
 
-        const logs = errors.filter((error) => error.level === LogLevels.ERROR);
+        const logs = errors.filter((error) => error.level === LogLevels.WARN);
 
         expect(logs).toHaveLength(1);
     });


### PR DESCRIPTION
## Description

The YFM021 rule has been changed from ERROR to WARN. The tests for this rule have also been adjusted.

Related issue: #367
